### PR TITLE
changes in webpack.config for issue #22 | tsconfig with explanatory comments, 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9894,6 +9894,77 @@
             "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
             "dev": true
         },
+        "ts-loader": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-7.0.5.tgz",
+            "integrity": "sha512-zXypEIT6k3oTc+OZNx/cqElrsbBtYqDknf48OZos0NQ3RTt045fBIU8RRSu+suObBzYB355aIPGOe/3kj9h7Ig==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^4.0.0",
+                "loader-utils": "^1.0.2",
+                "micromatch": "^4.0.0",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
         "tslib": {
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "lint-staged": "^10.2.11",
         "prettier": "^2.0.5",
         "style-loader": "^1.2.1",
+        "ts-loader": "^7.0.5",
         "typescript": "^3.9.5",
         "webpack": "^4.43.0",
         "webpack-cli": "^3.3.11",

--- a/src/@types/custom.d.ts
+++ b/src/@types/custom.d.ts
@@ -1,0 +1,13 @@
+// https://webpack.js.org/guides/typescript/#importing-other-assets
+declare module "*.png" {
+	const content: any;
+	export default content;
+}
+declare module "*.jpg" {
+	const content: any;
+	export default content;
+}
+declare module "*.gif" {
+	const content: any;
+	export default content;
+}

--- a/src/components/testing/TimingTesting.tsx
+++ b/src/components/testing/TimingTesting.tsx
@@ -71,7 +71,7 @@ const res = [
 @observer
 export class TimingTesting extends Component {
 	tpq = 240;
-	interval: NodeJS.Timeout | number | undefined;
+	interval: NodeJS.Timeout | undefined;
 	@observable currentTick = 0;
 	@observable markerTicks = range(0, 100, 5);
 

--- a/src/components/testing/TimingTesting.tsx
+++ b/src/components/testing/TimingTesting.tsx
@@ -10,7 +10,7 @@ interface TPSChange {
 	endTPS: number;
 }
 
-let synth = new Synth().toDestination();
+const synth = new Synth().toDestination();
 
 Transport.bpm.value = 1 * 60;
 Transport.PPQ = 1;
@@ -71,7 +71,7 @@ const res = [
 @observer
 export class TimingTesting extends Component {
 	tpq = 240;
-	interval: NodeJS.Timeout | undefined;
+	interval: NodeJS.Timeout | number | undefined;
 	@observable currentTick = 0;
 	@observable markerTicks = range(0, 100, 5);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,34 +1,73 @@
 {
-    "compileOnSave": false,
-    "compilerOptions": {
-        "allowJs": true,
-        "allowSyntheticDefaultImports": true,
-        "esModuleInterop": true,
-        "experimentalDecorators": true,
-        "forceConsistentCasingInFileNames": true,
-        "isolatedModules": true,
-        "jsx": "react",
-        "lib": [
-            "dom",
-            "dom.iterable",
-            "esnext"
-        ],
-        "module": "esnext",
-        "moduleResolution": "node",
-        "noEmit": true,
-        "noFallthroughCasesInSwitch": true,
-        "noImplicitAny": true,
-        "noUnusedLocals": true,
-        "outDir": "./dist/",
-        "resolveJsonModule": true,
-        "skipLibCheck": true,
-        "strict": true,
-        "target": "es5",
-    },
-    "exclude": [
-        "node_modules"
-    ],
-    "include": [
-        "src"
-    ]
+	"compileOnSave": false,
+	"exclude": [
+		"node_modules"
+	],
+	"include": [
+		"src"
+	],
+	"compilerOptions": {
+		"declaration": true, /* Generates corresponding '.d.ts' file. */
+		"isolatedModules": true, /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+		"jsx": "react", /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+		"lib": [
+			"dom",
+			"dom.iterable",
+			"esnext"
+		], /* Specify library files to be included in the compilation. */
+		"module": "esnext", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+		"noEmit": false, /* Do not emit outputs. */
+		"outDir": "./dist/", /* Redirect output structure to the directory. */
+		"target": "ES5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+		// "allowJs": true,                       /* Allow javascript files to be compiled. */
+		// "checkJs": true,                       /* Report errors in .js files. */
+		// "composite": true,                     /* Enable project compilation */
+		// "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+		// "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+		// "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+		// "outFile": "./",                       /* Concatenate and emit output to single file. */
+		// "removeComments": true,                /* Do not emit comments to output. */
+		// "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+		// "sourceMap": true,                     /* Generates corresponding '.map' file. */
+		/* Strict Type-Checking Options */
+		"noImplicitAny": true, /* Raise error on expressions and declarations with an implied 'any' type. */
+		"strict": true, /* Enable all strict type-checking options. */
+		// "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+		// "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+		// "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+		// "strictNullChecks": true,              /* Enable strict null checks. */
+		// "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+		/* Additional Checks */
+		"forceConsistentCasingInFileNames": true,
+		"noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+		"noUnusedLocals": false, /* Report errors on unused locals. */
+		"resolveJsonModule": true,
+		// "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+		// "noUnusedParameters": true,            /* Report errors on unused parameters. */
+		// "skipLibCheck": true,
+		/* Module Resolution Options */
+		"allowSyntheticDefaultImports": true, /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+		"esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+		"moduleResolution": "node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+		// "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+		// "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+		// "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+		// "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+		"typeRoots": [
+			"node_modules/@types",
+			"./@types",
+			"./src/@types"
+		], /* List of folders to include type definitions from. */
+		// "types": [],                           /* Type declaration files to be included in compilation. */
+		/* Source Map Options */
+		// "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+		// "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+		// "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+		// "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+		/* Experimental Options */
+		"experimentalDecorators": true, /* Enables experimental support for ES7 decorators. */
+		// "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+		/* Advanced Options */
+		// "declarationDir": "lib"                /* Output directory for generated declaration files. */
+	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,9 +54,9 @@
 		// "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 		// "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
 		"typeRoots": [
-			"node_modules/@types",
 			"./@types",
-			"./src/@types"
+			"./src/@types",
+			"node_modules/@types",
 		], /* List of folders to include type definitions from. */
 		// "types": [],                           /* Type declaration files to be included in compilation. */
 		/* Source Map Options */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,30 +21,59 @@ module.exports = {
 
     // adding .ts and .tsx to resolve.extensions will help babel look for .ts and .tsx files to transpile
     resolve: {
-        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+		// Note: order matters here as well
+		extensions: ['.ts', '.tsx', '.js', '.jsx'], 
     },
 
     module: {
         rules: [
-            // we use babel-loader to load our jsx and tsx files
-            {
-                test: /\.(ts|js)x?$/,
-                exclude: /node_modules/,
-                use: {
-                    loader: 'babel-loader',
-                },
-            },
+            // we use babel-loader to load our jsx and tsx file
+			// https://stackoverflow.com/questions/49624202/why-use-babel-loader-with-ts-loader
+			{
+				test: /\.tsx?$/,
+				// Note: using include is more maintainable and efficient.
+				include: [path.resolve(__dirname, 'src'), /vmmx-schema/],
+				use: [
+					{
+                        // First use babel loader(with typescript preset) to transpile latest features (without typechecking)
+						loader: 'babel-loader',
+						options: {
+							// https://webpack.js.org/loaders/babel-loader/#babel-loader-is-slow
+							cacheDirectory: true
+						}
+					},
+					{
+						// type check the output from the previous loader
+						loader: 'ts-loader',
+						options: {
+							// for re-compiling .ts files in vmmx-schema
+							"allowTsInNodeModules": true
+						}
+					}
+				]
+			}, 
+			{
+				test: /\.jsx?$/,
+				include: [path.resolve(__dirname, 'src')],
+				use: [
+					{
+						loader: 'babel-loader',
+					}
+				]
+			},
 
-            // css-loader to bundle all the css files into one file and style-loader to add all the styles  inside the style tag of the document
-            {
-                test: /\.css$/,
-                use: ['style-loader', 'css-loader'],
-            },
-            // file-loader to make images importable
-            {
-                test: /\.(png|jpg|gif)$/i,
-                use: ['file-loader']
-            }
+			// css-loader to bundle all the css files into one file and style-loader to add all the styles  inside the style tag of the document
+			{
+				test: /\.css$/,
+				include: [path.resolve(__dirname, 'src'), /node_modules/],
+				use: ['style-loader', 'css-loader'],
+			},
+			// file-loader to make images importable
+			{
+				test: /\.(png|jpg|gif)$/i,
+				include: [path.resolve(__dirname, 'src')],
+				use: ['file-loader']
+			},
         ],
     },
     plugins: [


### PR DESCRIPTION
Resolves #22

Some analysis: 

### **Build** timings checks 

Command used -
> time npm run build

Then (with react-scripts and other bloatware) (refer **total**)
```
1. npm run build  58.57s user 5.48s system 168% cpu 37.973 total
2. npm run build  29.30s user 3.31s system 212% cpu 15.333 total
3. npm run build  28.26s user 3.27s system 210% cpu 14.986 total
```

Now (with manual webpack config)
```
1. npm run build  24.79s user 1.67s system 155% cpu 17.068 total
2. npm run build  19.99s user 1.93s system 157% cpu 13.929 total
3. npm run build  18.73s user 1.57s system 162% cpu 12.522 total
```

### **Dev** timings checks 
Although not so reliable, mentioning this just as part of an experiment

Command used (with ^C just after Compiled Successfully message)-
> time npm run start 

Then
```
1. npm run start  0.32s user 0.11s system 4% cpu 10.030 total
2. npm run start  0.31s user 0.10s system 4% cpu 8.994 total
3. npm run start  0.26s user 0.09s system 4% cpu 8.080 total
```

Now
```
1. npm run start  17.46s user 1.74s system 149% cpu 12.852 total
2. npm run start  17.26s user 1.71s system 157% cpu 12.021 total
3. npm run start  17.37s user 1.71s system 153% cpu 12.410 total
```
The ~3 second increase in first compile is most likely due to the fact that it now also compiles vmmx-schema (temporarily #22)