### PR TITLE
Top pin can now be placed, started internal doc

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,5 @@
+# Documentation
+
+This is currently raw documentation, where details on the machine and its implementation are noted.  
+This is very much a work in progress, therefore don't expect much in here at the moment.
+

--- a/doc/programming wheel/README.md
+++ b/doc/programming wheel/README.md
@@ -1,0 +1,28 @@
+# Layout
+
+The code for the programming wheel is in `src/components/programmingWheel`
+Here is how the SVG is structured.
+
+Most of the positioning is done via `transform: translate(x,y)` on the wrapping `g` element.
+
+- `svg`
+  - `g` - Everything
+    - `g` - wrapper for the cols and pins
+      - `g[]` - One group per column
+        - `rect` - First element: Background color
+        - `g > rect` - Pins of the column
+    - `g` - Wrapper for the dividing lines
+      - `g[] > line` - Dividing lines (Horizontal)
+    - `g` - Current hovered square
+    - `g` - Green line, current position when playing the song
+    - `g` - Red line, not sure what it does yet
+
+## Hovered area
+Instead of changing the background color of the highlighted area,
+there is a single rectangle moving towards the area below the cursor.
+
+The code for this area is under `src/components/programmingWheel/PegPlacer.tsx`
+
+I assume it was done this way as there is only one `rect` for the column background, therefore it can't be changed in a granular way.
+
+I would prefer eventually switching it up to a regular grid, where there are `rows[] > cols[] > cell`, I feel like it might be better for the maintenance and futur development of the programming wheel.

--- a/src/components/programmingWheel/PegPlacer.tsx
+++ b/src/components/programmingWheel/PegPlacer.tsx
@@ -24,14 +24,14 @@ export const PegPlacer = () => {
 	const alreadyPlaced = () => {
 		const t = timeline();
 		const mouseTick = mouseSnapped()?.mouseTick;
-		if (!mouseTick || !t) return true;
+		if (mouseTick === undefined || mouseTick < 0 || !t) return true;
 		return t.events().some((e) => e.tick() === mouseTick);
 	};
 
 	function addPeg() {
 		const t = timeline();
 		const mouseTick = mouseSnapped()?.mouseTick;
-		if (!mouseTick || !t) return;
+		if (mouseTick === undefined || mouseTick < 0 || !t) return;
 		const difs = t.getAddDifs(new DropE({ tick: mouseTick }));
 		if (!difs) return;
 		t.applyDifs(difs);


### PR DESCRIPTION
When `mouseTick` had a value of `0`, it was treated as `undefined` due to the `falsy` nature of the value.  
Switched it with an explicit verification, and fixed a bug where the value could be `-60` when the cursor was hovering the top pixel of the region.

Also started an internal doc, this is mostly to document the reasoning and high level functionality of features, mostly so there is _something_ to get it started!

Bug from #42 